### PR TITLE
Added RegExp

### DIFF
--- a/NPE-Files/_plugins_stts/Pocketsphinx/readme.md
+++ b/NPE-Files/_plugins_stts/Pocketsphinx/readme.md
@@ -298,7 +298,7 @@ I'm not exactly sure why this is, but apparently it is necessary to reformat the
 
 ```shell
 [~/pocketsphinx-python]$ cd pocketsphinx/model/en-us
-[~/pocketsphinx-python/pocketsphinx/model/en-us]$ cat cmudict-en-us.dict | perl -pe 's/^([^\s]*)\(([0-9]+)\)/\1/;s/\s+/ /g;s/^\s+//;s/\s+$//; @_=split(/\s+/); $w=shift(@_);$_=$w."\t".join(" ",@_)."\n";' > cmudict-en-us.formatted.dict
+[~/pocketsphinx-python/pocketsphinx/model/en-us]$ cat cmudict-en-us.dict | perl -pe 's/^([^\s]*)\(([0-9]+)\)/\1/;s/\s+/ /g;s/^\s+//;s/\s+$//;s/[\}\|\_]/ /g;@_=split(/\s+/); $w=shift(@_);$_=$w."\t".join(" ",@_)."\n";' > cmudict-en-us.formatted.dict
 [~/pocketsphinx-python/pocketsphinx/model/en-us]$ phonetisaurus-train --lexicon cmudict-en-us.formatted.dict --seq2_del
 [~/pocketsphinx-python/pocketsphinx/model/en-us]$ cd
 ```


### PR DESCRIPTION
Added a small regexp to replace the three characters Phonetisaurus checks for ("_" - underscore, "}" - right curly bracket, and "|" - pipe) with spaces in the formatted cmu dictionary. This came up because I enabled the standard French model and phonetisaurus blew up because there was an underscore in the "a_contrario" entry. After applying this change, I was able to compile the French model correctly.